### PR TITLE
Bump from net452 to net462

### DIFF
--- a/source/Shellfish/Shellfish.csproj
+++ b/source/Shellfish/Shellfish.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>


### PR DESCRIPTION
As 4.5.2 is EOL on Apr 26, 2022.

A GitHub [search](https://github.com/search?p=1&q=org%3AOctopusDeploy+shellfish&type=Code) shows this is not used in any projects that rely on net452.