### PR TITLE
Remove EOL .NET and consolidate targets

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.302",
+    "version": "6.0.301",
     "rollForward": "latestFeature"
   }
 }

--- a/source/Shellfish/Shellfish.csproj
+++ b/source/Shellfish/Shellfish.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Authors>Octopus Deploy</Authors>
@@ -11,27 +11,17 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>8</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net462;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Management" Version="4.7.0" />
+    <PackageReference Include="System.Management" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.7.0" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="6.0.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">

--- a/source/Shellfish/Windows/WindowStationAndDesktopAccess.cs
+++ b/source/Shellfish/Windows/WindowStationAndDesktopAccess.cs
@@ -30,10 +30,8 @@ namespace Octopus.Shellfish.Windows
                     AccessControlSections.Access);
 
             var account = string.IsNullOrEmpty(domainName)
-#pragma warning disable PC001 // API not supported on all platforms
                 ? new NTAccount(username)
-                : new NTAccount(domainName, username);
-#pragma warning restore PC001 // API not supported on all platforms
+                : new NTAccount(domainName!, username);
 
             security.AddAccessRule(
                 new GenericAccessRule(

--- a/source/Tests/Plumbing/TestUserPrincipal.cs
+++ b/source/Tests/Plumbing/TestUserPrincipal.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.DirectoryServices.AccountManagement;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Security.Principal;
 
 namespace Tests.Plumbing
@@ -9,6 +10,11 @@ namespace Tests.Plumbing
     {
         public TestUserPrincipal(string username, string password = "Password01!")
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException();
+            }
+
             try
             {
                 using (var principalContext = new PrincipalContext(ContextType.Machine))
@@ -51,7 +57,8 @@ namespace Tests.Plumbing
         }
 
         public SecurityIdentifier Sid { get; }
-        public string NTAccountName => Sid.Translate(typeof(NTAccount)).ToString();
+
+        public string NTAccountName => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Sid.Translate(typeof(NTAccount)).ToString() : throw new PlatformNotSupportedException();
         public string DomainName => NTAccountName.Split(new[] { '\\' }, 2)[0];
         public string UserName => NTAccountName.Split(new[] { '\\' }, 2)[1];
         public string SamAccountName { get; }

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Tests</AssemblyName>
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`net5.0` was EOL in April 2022 and `netcoreapp3.1` will be EOL in December 2022. This PR removes those targets and consolidates the others to `netstandard2.0`, which is supported by both NET6 and NET Framework 4.6.2.