### PR TITLE
Updated the version of .Net that Nuke will use

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -24,7 +24,10 @@ class Build : NukeBuild
 
     [Parameter("Whether to auto-detect the branch name - this is okay for a local build, but should not be used under CI.")] readonly bool AutoDetectBranch = IsLocalBuild;
 
-    [OctoVersion(BranchParameter = nameof(BranchName), AutoDetectBranchParameter = nameof(AutoDetectBranch))] public OctoVersionInfo OctoVersionInfo;
+    [OctoVersion(Framework = "net6.0",
+        BranchParameter = nameof(BranchName), 
+        AutoDetectBranchParameter = nameof(AutoDetectBranch))] 
+    public OctoVersionInfo OctoVersionInfo;
 
     [Parameter("Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable " + CiBranchNameEnvVariable + ".", Name = CiBranchNameEnvVariable)]
     string BranchName { get; set; }


### PR DESCRIPTION
Updated the version of .Net that Nuke will try and use, now that .ne 5 has been removed from out build agents.