### PR TITLE
Don't call UnloadUserProfile twice

### DIFF
--- a/source/Shellfish/Windows/UserProfile.cs
+++ b/source/Shellfish/Windows/UserProfile.cs
@@ -30,7 +30,7 @@ namespace Octopus.Shellfish.Windows
             return new UserProfile(token, new SafeRegistryHandle(userProfile.hProfile, false));
         }
 
-        public void Unload()
+        void Unload()
         {
             // See https://msdn.microsoft.com/en-us/library/windows/desktop/bb762282(v=vs.85).aspx
             // This function closes the registry handle for the user profile too
@@ -42,15 +42,7 @@ namespace Octopus.Shellfish.Windows
         {
             if (userProfile != null && !userProfile.IsClosed)
             {
-                try
-                {
-                    Unload();
-                }
-                catch
-                {
-                    // Don't throw in dispose method
-                }
-
+                Unload();
                 userProfile.Dispose();
             }
         }

--- a/source/Shellfish/Windows/WindowsEnvironmentVariableHelper.cs
+++ b/source/Shellfish/Windows/WindowsEnvironmentVariableHelper.cs
@@ -58,10 +58,9 @@ namespace Octopus.Shellfish.Windows
 
                 Dictionary<string, string> targetUserEnvironmentVariables;
                 using (var token = AccessToken.Logon(runAs.UserName, runAs.Password, runAs.Domain))
-                using (var userProfile = UserProfile.Load(token))
+                using (UserProfile.Load(token))
                 {
                     targetUserEnvironmentVariables = EnvironmentBlock.GetEnvironmentVariablesForUser(token, false);
-                    userProfile.Unload();
                 }
 
                 // Cache the target user's environment variables so we don't have to load them every time


### PR DESCRIPTION
The Windows API call UnloadUserProfile was being called directly via `userProfile.Unload` when the dispose method (via the `using` block) was about to do the same.

This PR fixes that, preventing potential undefined behaviour due to closing incorrect handles.