### PR TITLE
Bringing ShellExecutor inline with Octopus.Shared version

### DIFF
--- a/source/Shellfish/ShellExecutor.cs
+++ b/source/Shellfish/ShellExecutor.cs
@@ -184,7 +184,8 @@ namespace Octopus.Shellfish
             {
                 return process.ExitCode;
             }
-            catch (InvalidOperationException ex) when (ex.Message == "No process is associated with this object.")
+            catch (InvalidOperationException ex)
+                when (ex.Message is "No process is associated with this object." || ex.Message is "Process was not started by this object, so requested information cannot be determined.")
             {
                 return -1;
             }


### PR DESCRIPTION
[sc-53693]

# Background
A Halibut integration test was failing (details in linked Shortcut story). 

# Results


## Before
A `Process was not started by this object, so requested information cannot be determined.` exception was being thrown from `System.Process` when Shellfish was accessing the exit code of the process.

Shellfish already wraps this property in a try/catch, but it doesn't listen for this error.

## After
We updated the `ShellExecutor` to be inline with [the latest version](https://github.com/OctopusDeploy/OctopusDeploy/blob/2325337898ba628df7e5ef58f8a044dd8e1f51f1/source/Octopus.Shared/Util/SilentProcessRunner.cs#L281) of `Octopus.Shared`, which handles the exception case that was causing the tests to fail.

# How to review this PR


Quality :heavy_check_mark: