### PR TITLE
Split windows tests into different class, use ClassFixture to reduce setup cost

### DIFF
--- a/source/Tests/ShellExecutorFixture.Windows.cs
+++ b/source/Tests/ShellExecutorFixture.Windows.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using FluentAssertions;
+using Octopus.Shellfish.Plumbing;
+using Tests.Plumbing;
+using Xunit;
+
+namespace Tests
+{
+    public class ShellExecutorFixtureWindows(ShellExecutorFixtureWindows.ClassFixture fx) : IClassFixture<ShellExecutorFixtureWindows.ClassFixture>
+    {
+        // Multiple tests want this TestUserPrincipal to exist, but they don't modify it.
+        // We can save a significant amount of time by creating it once up-front
+        public class ClassFixture
+        {
+            internal TestUserPrincipal User { get; } = new(Username);
+        }
+        
+        // ReSharper disable InconsistentNaming
+        const string Username = "test-shellexecutor";
+
+        static readonly string Command = "cmd.exe";
+        static readonly string CommandParam = "/c";
+
+        // Mimic the cancellation behaviour from LoggedTest in Octopus Server; we can't reference it in this assembly
+        static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(45);
+
+        readonly CancellationTokenSource cancellationTokenSource = new(TestTimeout);
+        CancellationToken CancellationToken => cancellationTokenSource.Token;
+
+        readonly TestUserPrincipal user = fx.User;
+
+        [WindowsFact]
+        public void DebugLogging_ShouldContainDiagnosticsInfo_DifferentUser()
+        {
+            var arguments = $"{CommandParam} \"echo %userdomain%\\%username%\"";
+            // Target the CommonApplicationData folder since this is a place the particular user can get to
+            var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            var networkCredential = user.GetCredential();
+            var customEnvironmentVariables = new Dictionary<string, string>();
+
+            var exitCode = ShellExecutorFixture.Execute(Command,
+                arguments,
+                workingDirectory,
+                out var debugMessages,
+                out var infoMessages,
+                out var errorMessages,
+                networkCredential,
+                customEnvironmentVariables,
+                CancellationToken);
+
+            exitCode.Should().Be(0, "the process should have run to completion");
+            debugMessages.ToString()
+                .Should()
+                .ContainEquivalentOf(Command, "the command should be logged")
+                .And.ContainEquivalentOf($@"{user.DomainName}\{user.UserName}", "the custom user details should be logged")
+                .And.ContainEquivalentOf(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "the working directory should be logged");
+            infoMessages.ToString().Should().ContainEquivalentOf($@"{user.DomainName}\{user.UserName}");
+            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
+        }
+
+        [WindowsFact]
+        public void RunningAsDifferentUser_ShouldCopySpecialEnvironmentVariables()
+        {
+            var arguments = $"{CommandParam} \"echo {EchoEnvironmentVariable("customenvironmentvariable")}\"";
+            // Target the CommonApplicationData folder since this is a place the particular user can get to
+            var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            var networkCredential = user.GetCredential();
+            var customEnvironmentVariables = new Dictionary<string, string>
+            {
+                { "customenvironmentvariable", "customvalue" }
+            };
+
+            var exitCode = ShellExecutorFixture.Execute(Command,
+                arguments,
+                workingDirectory,
+                out _,
+                out var infoMessages,
+                out var errorMessages,
+                networkCredential,
+                customEnvironmentVariables,
+                CancellationToken);
+
+            exitCode.Should().Be(0, "the process should have run to completion");
+            infoMessages.ToString().Should().ContainEquivalentOf("customvalue", "the environment variable should have been copied to the child process");
+            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
+        }
+
+        [WindowsFact]
+        public void RunningAsDifferentUser_ShouldWorkLotsOfTimes()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(240));
+
+            for (var i = 0; i < 20; i++)
+            {
+                var arguments = $"{CommandParam} \"echo {EchoEnvironmentVariable("customenvironmentvariable")}%\"";
+                // Target the CommonApplicationData folder since this is a place the particular user can get to
+                var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+                var networkCredential = user.GetCredential();
+                var customEnvironmentVariables = new Dictionary<string, string>
+                {
+                    { "customenvironmentvariable", $"customvalue-{i}" }
+                };
+
+                var exitCode = ShellExecutorFixture.Execute(Command,
+                    arguments,
+                    workingDirectory,
+                    out _,
+                    out var infoMessages,
+                    out var errorMessages,
+                    networkCredential,
+                    customEnvironmentVariables,
+                    cts.Token);
+
+                exitCode.Should().Be(0, "the process should have run to completion");
+                infoMessages.ToString().Should().ContainEquivalentOf($"customvalue-{i}", "the environment variable should have been copied to the child process");
+                errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
+            }
+        }
+
+        [WindowsFact]
+        public void RunningAsDifferentUser_CanWriteToItsOwnTempPath()
+        {
+            var arguments = $"{CommandParam} \"echo hello > %temp%hello.txt\"";
+            // Target the CommonApplicationData folder since this is a place the particular user can get to
+            var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            var networkCredential = user.GetCredential();
+            var customEnvironmentVariables = new Dictionary<string, string>();
+
+            var exitCode = ShellExecutorFixture.Execute(Command,
+                arguments,
+                workingDirectory,
+                out _,
+                out _,
+                out var errorMessages,
+                networkCredential,
+                customEnvironmentVariables,
+                CancellationToken);
+
+            exitCode.Should().Be(0, "the process should have run to completion after writing to the temp folder for the other user");
+            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
+        }
+
+        [WindowsTheory]
+        [InlineData("powershell.exe", "-command \"Write-Host $env:userdomain\\$env:username\"")]
+        public void RunAsCurrentUser_PowerShell_ShouldWork(string command, string arguments)
+        {
+            var workingDirectory = "";
+            var networkCredential = default(NetworkCredential);
+            var customEnvironmentVariables = new Dictionary<string, string>();
+
+            var exitCode = ShellExecutorFixture.Execute(command,
+                arguments,
+                workingDirectory,
+                out _,
+                out var infoMessages,
+                out var errorMessages,
+                networkCredential,
+                customEnvironmentVariables,
+                CancellationToken);
+
+            exitCode.Should().Be(0, "the process should have run to completion");
+            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
+            infoMessages.ToString().Should().ContainEquivalentOf($@"{Environment.UserDomainName}\{Environment.UserName}");
+        }
+
+        [WindowsTheory]
+        [InlineData("cmd.exe", "/c \"echo %userdomain%\\%username%\"")]
+        [InlineData("powershell.exe", "-command \"Write-Host $env:userdomain\\$env:username\"")]
+        public void RunAsDifferentUser_ShouldWork(string command, string arguments)
+        {
+            // Target the CommonApplicationData folder since this is a place the particular user can get to
+            var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            var networkCredential = user.GetCredential();
+            var customEnvironmentVariables = new Dictionary<string, string>();
+
+            var exitCode = ShellExecutorFixture.Execute(command,
+                arguments,
+                workingDirectory,
+                out _,
+                out var infoMessages,
+                out var errorMessages,
+                networkCredential,
+                customEnvironmentVariables,
+                CancellationToken);
+
+            exitCode.Should().Be(0, "the process should have run to completion");
+            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
+            infoMessages.ToString().Should().ContainEquivalentOf($@"{user.DomainName}\{user.UserName}");
+        }
+
+        static string EchoEnvironmentVariable(string varName) => $"%{varName}%";
+    }
+}

--- a/source/Tests/ShellExecutorFixture.cs
+++ b/source/Tests/ShellExecutorFixture.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using Octopus.Shellfish;
 using Octopus.Shellfish.Plumbing;
 using Octopus.Shellfish.Windows;
-using Tests.Plumbing;
 using Xunit;
 
 namespace Tests
@@ -18,7 +17,6 @@ namespace Tests
         // ReSharper disable InconsistentNaming
         const int SIG_TERM = 143;
         const int SIG_KILL = 137;
-        const string Username = "test-shellexecutor";
 
         static readonly string Command = PlatformDetection.IsRunningOnWindows ? "cmd.exe" : "bash";
         static readonly string CommandParam = PlatformDetection.IsRunningOnWindows ? "/c" : "-c";
@@ -106,125 +104,6 @@ namespace Tests
 
             exitCode.Should().Be(0, "the process should have run to completion");
             infoMessages.ToString().Should().ContainEquivalentOf("customvalue", "the environment variable should have been copied to the child process");
-            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-        }
-
-        [WindowsFact]
-        public void DebugLogging_ShouldContainDiagnosticsInfo_DifferentUser()
-        {
-            var user = new TestUserPrincipal(Username);
-
-            var arguments = $"{CommandParam} \"echo %userdomain%\\%username%\"";
-            // Target the CommonApplicationData folder since this is a place the particular user can get to
-            var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            var networkCredential = user.GetCredential();
-            var customEnvironmentVariables = new Dictionary<string, string>();
-
-            var exitCode = Execute(Command,
-                arguments,
-                workingDirectory,
-                out var debugMessages,
-                out var infoMessages,
-                out var errorMessages,
-                networkCredential,
-                customEnvironmentVariables,
-                CancellationToken);
-
-            exitCode.Should().Be(0, "the process should have run to completion");
-            debugMessages.ToString()
-                .Should()
-                .ContainEquivalentOf(Command, "the command should be logged")
-                .And.ContainEquivalentOf($@"{user.DomainName}\{user.UserName}", "the custom user details should be logged")
-                .And.ContainEquivalentOf(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "the working directory should be logged");
-            infoMessages.ToString().Should().ContainEquivalentOf($@"{user.DomainName}\{user.UserName}");
-            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-        }
-
-        [WindowsFact]
-        public void RunningAsDifferentUser_ShouldCopySpecialEnvironmentVariables()
-        {
-            var user = new TestUserPrincipal(Username);
-
-            var arguments = $"{CommandParam} \"echo {EchoEnvironmentVariable("customenvironmentvariable")}\"";
-            // Target the CommonApplicationData folder since this is a place the particular user can get to
-            var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            var networkCredential = user.GetCredential();
-            var customEnvironmentVariables = new Dictionary<string, string>
-            {
-                { "customenvironmentvariable", "customvalue" }
-            };
-
-            var exitCode = Execute(Command,
-                arguments,
-                workingDirectory,
-                out _,
-                out var infoMessages,
-                out var errorMessages,
-                networkCredential,
-                customEnvironmentVariables,
-                CancellationToken);
-
-            exitCode.Should().Be(0, "the process should have run to completion");
-            infoMessages.ToString().Should().ContainEquivalentOf("customvalue", "the environment variable should have been copied to the child process");
-            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-        }
-
-        [WindowsFact]
-        public void RunningAsDifferentUser_ShouldWorkLotsOfTimes()
-        {
-            var user = new TestUserPrincipal(Username);
-
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(240));
-
-            for (var i = 0; i < 20; i++)
-            {
-                var arguments = $"{CommandParam} \"echo {EchoEnvironmentVariable("customenvironmentvariable")}%\"";
-                // Target the CommonApplicationData folder since this is a place the particular user can get to
-                var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-                var networkCredential = user.GetCredential();
-                var customEnvironmentVariables = new Dictionary<string, string>
-                {
-                    { "customenvironmentvariable", $"customvalue-{i}" }
-                };
-
-                var exitCode = Execute(Command,
-                    arguments,
-                    workingDirectory,
-                    out _,
-                    out var infoMessages,
-                    out var errorMessages,
-                    networkCredential,
-                    customEnvironmentVariables,
-                    cts.Token);
-
-                exitCode.Should().Be(0, "the process should have run to completion");
-                infoMessages.ToString().Should().ContainEquivalentOf($"customvalue-{i}", "the environment variable should have been copied to the child process");
-                errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-            }
-        }
-
-        [WindowsFact]
-        public void RunningAsDifferentUser_CanWriteToItsOwnTempPath()
-        {
-            var user = new TestUserPrincipal(Username);
-
-            var arguments = $"{CommandParam} \"echo hello > %temp%hello.txt\"";
-            // Target the CommonApplicationData folder since this is a place the particular user can get to
-            var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            var networkCredential = user.GetCredential();
-            var customEnvironmentVariables = new Dictionary<string, string>();
-
-            var exitCode = Execute(Command,
-                arguments,
-                workingDirectory,
-                out _,
-                out _,
-                out var errorMessages,
-                networkCredential,
-                customEnvironmentVariables,
-                CancellationToken);
-
-            exitCode.Should().Be(0, "the process should have run to completion after writing to the temp folder for the other user");
             errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
         }
 
@@ -334,60 +213,10 @@ namespace Tests
             infoMessages.ToString().Should().ContainEquivalentOf($@"{Environment.UserName}");
         }
 
-        [WindowsTheory]
-        [InlineData("powershell.exe", "-command \"Write-Host $env:userdomain\\$env:username\"")]
-        public void RunAsCurrentUser_PowerShell_ShouldWork(string command, string arguments)
-        {
-            var workingDirectory = "";
-            var networkCredential = default(NetworkCredential);
-            var customEnvironmentVariables = new Dictionary<string, string>();
-
-            var exitCode = Execute(command,
-                arguments,
-                workingDirectory,
-                out _,
-                out var infoMessages,
-                out var errorMessages,
-                networkCredential,
-                customEnvironmentVariables,
-                CancellationToken);
-
-            exitCode.Should().Be(0, "the process should have run to completion");
-            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-            infoMessages.ToString().Should().ContainEquivalentOf($@"{Environment.UserDomainName}\{Environment.UserName}");
-        }
-
-        [WindowsTheory]
-        [InlineData("cmd.exe", "/c \"echo %userdomain%\\%username%\"")]
-        [InlineData("powershell.exe", "-command \"Write-Host $env:userdomain\\$env:username\"")]
-        public void RunAsDifferentUser_ShouldWork(string command, string arguments)
-        {
-            var user = new TestUserPrincipal(Username);
-
-            // Target the CommonApplicationData folder since this is a place the particular user can get to
-            var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            var networkCredential = user.GetCredential();
-            var customEnvironmentVariables = new Dictionary<string, string>();
-
-            var exitCode = Execute(command,
-                arguments,
-                workingDirectory,
-                out _,
-                out var infoMessages,
-                out var errorMessages,
-                networkCredential,
-                customEnvironmentVariables,
-                CancellationToken);
-
-            exitCode.Should().Be(0, "the process should have run to completion");
-            errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-            infoMessages.ToString().Should().ContainEquivalentOf($@"{user.DomainName}\{user.UserName}");
-        }
-
         static string EchoEnvironmentVariable(string varName)
             => PlatformDetection.IsRunningOnWindows ? $"%{varName}%" : $"${varName}";
 
-        static int Execute(
+        public static int Execute(
             string command,
             string arguments,
             string workingDirectory,


### PR DESCRIPTION
# Background

I found as part of working on API improvements, that the current set of tests took quite a long time.

E.g. from a [recent build](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Libraries_Shellfish_BuildAndTestWindows/14848178?buildTab=log&focusLine=0&logView=flowAware&linesState=425) on `main`

The **Build and Test: Windows** Job took 3m53s
The Nuke **Test** target took 1m16s

There are two reasons for this
1. All the tests are contained in a single class `ShellExecutorFixture` so xUnit can't run any of them in parallel
2. The tests which require a Windows User attempt to create one at the beginning of each test. While they only create the account if it's not already there, the simple existence check is expensive.

# Results

- Splits the windows-only tests (which require the User) into their own class. xUnit can now run these in parallel with the rest of the tests

- Uses a ClassFixture to create (or lookup) the User Account once, and it is then reused for the individual tests. This is safe to do as the tests themselves don't modify the User Account at all.

### Speedup

With this PR,
The **Build and Test: Windows** Job took 3m12s
The Nuke **Test** target took 50s

While this is not super meaningful for TeamCity, it's much more impactful when running the tests locally, because you're _only_ running the tests, not doing the compile or anything else. A 25 second drop while you're staring at your screen waiting for the results makes a big difference.

# Reducing Risk

This doesn't change any of the tests or code at all, it just moves them. It should be very safe.