### PR TITLE
Make IInputSource private; we do not want to commit to this exact API yet

### DIFF
--- a/source/Shellfish/IInputSource.cs
+++ b/source/Shellfish/IInputSource.cs
@@ -2,12 +2,14 @@ using System;
 
 namespace Octopus.Shellfish;
 
-public interface IInputSource
+// Experimental: We are not 100% sure this is the right way to implement stdin
+internal interface IInputSource
 {
     IDisposable Subscribe(IInputSourceObserver observer);
 }
 
-public interface IInputSourceObserver
+// Experimental: We are not 100% sure this is the right way to implement stdin
+internal interface IInputSourceObserver
 {
     void OnNext(string line);
     void OnCompleted();

--- a/source/Shellfish/InputQueue.cs
+++ b/source/Shellfish/InputQueue.cs
@@ -9,7 +9,7 @@ namespace Octopus.Shellfish;
 // it may block or throw exceptions. Both the blocking and exception throwing could leak
 // out to the caller and cause unexpected problems. To solve these, we queue input and process
 // it asynchronously in the background
-public class InputQueue : IInputSourceObserver
+class InputQueue : IInputSourceObserver
 {
     readonly Queue<Notification> queue = new(); // serves as the lock-object for this instance
     readonly StreamWriter processStdInput;

--- a/source/Shellfish/ShellCommand.cs
+++ b/source/Shellfish/ShellCommand.cs
@@ -128,7 +128,8 @@ public class ShellCommand
         return this;
     }
 
-    public ShellCommand WithStdInSource(IInputSource source)
+    // Experimental: We are not 100% sure this is the right way to implement stdin
+    internal ShellCommand WithStdInSource(IInputSource source)
     {
         stdInSource = source;
         return this;

--- a/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
+++ b/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
@@ -3,11 +3,6 @@ Octopus.Shellfish.ShellCommandExtensionMethods.WithStdOutTarget
 Octopus.Shellfish.ShellCommandExtensionMethods.WithStdErrTarget
 Octopus.Shellfish.ShellCommandExtensionMethods.WithStdOutTarget
 Octopus.Shellfish.ShellCommandExtensionMethods.WithStdErrTarget
-Octopus.Shellfish.IInputSource.Subscribe
-Octopus.Shellfish.IInputSourceObserver.OnNext
-Octopus.Shellfish.IInputSourceObserver.OnCompleted
-Octopus.Shellfish.InputQueue.OnNext
-Octopus.Shellfish.InputQueue.OnCompleted
 Octopus.Shellfish.IOutputTarget.WriteLine
 Octopus.Shellfish.ShellCommand.WithWorkingDirectory
 Octopus.Shellfish.ShellCommand.WithArguments
@@ -16,7 +11,6 @@ Octopus.Shellfish.ShellCommand.WithEnvironmentVariables
 Octopus.Shellfish.ShellCommand.WithCredentials
 Octopus.Shellfish.ShellCommand.WithOutputEncoding
 Octopus.Shellfish.ShellCommand.WithStdOutTarget
-Octopus.Shellfish.ShellCommand.WithStdInSource
 Octopus.Shellfish.ShellCommand.WithStdErrTarget
 Octopus.Shellfish.ShellCommand.Execute
 Octopus.Shellfish.ShellCommand.ExecuteAsync


### PR DESCRIPTION
In a previous PR shellfish gained the ability to handle StdIn

It did this by exposing a low level IInputSource type which is similar to IObservable

We're not sure this is the right abstraction, so we're making it internal to avoid third parties locking onto it.

The `WithStdInSource(string)` method remains public, which is what people actually need right now