### PR TITLE
Change ShellCommand default behaviour not to swallow Cancellation exception

### DIFF
--- a/source/Shellfish/ShellCommand.cs
+++ b/source/Shellfish/ShellCommand.cs
@@ -24,7 +24,7 @@ public class ShellCommand
     NetworkCredential? windowsCredential;
     Encoding? outputEncoding;
     ShellCommandOptions commandOptions;
-    Action<int>? onCaptureProcessId;
+    Action<Process>? onCaptureProcess;
 
     List<IOutputTarget>? stdOutTargets;
     List<IOutputTarget>? stdErrTargets;
@@ -37,9 +37,9 @@ public class ShellCommand
     }
 
     // internal only, so tests can assert if a process has exited or not.
-    internal ShellCommand CaptureProcessId(Action<int> onProcessId)
+    internal ShellCommand CaptureProcess(Action<Process> onProcess)
     {
-        onCaptureProcessId = onProcessId;
+        onCaptureProcess = onProcess;
         return this;
     }
 
@@ -172,7 +172,7 @@ public class ShellCommand
         var exitedEvent = AttachProcessExitedManualResetEvent(process, cancellationToken);
         process.Start();
 
-        onCaptureProcessId?.Invoke(process.Id);
+        onCaptureProcess?.Invoke(process);
 
         IDisposable? closeStdInDisposable = BeginIoStreams(process, shouldBeginOutputRead, shouldBeginErrorRead, shouldBeginInput);
 
@@ -224,7 +224,7 @@ public class ShellCommand
         var exitedTask = AttachProcessExitedTask(process, cancellationToken);
         process.Start();
         
-        onCaptureProcessId?.Invoke(process.Id);
+        onCaptureProcess?.Invoke(process);
 
         IDisposable? closeStdInDisposable = BeginIoStreams(process, shouldBeginOutputRead, shouldBeginErrorRead, shouldBeginInput);
 

--- a/source/Shellfish/ShellCommandOptions.cs
+++ b/source/Shellfish/ShellCommandOptions.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Octopus.Shellfish;
+
+public enum ShellCommandOptions
+{
+    /// <summary>
+    /// Default value, equivalent to not specifying any options.
+    /// </summary>
+    None = 0,
+    
+    /// <summary>
+    /// By default, if the CancellationToken is cancelled, the running process will be killed, and an OperationCanceledException
+    /// will be thrown, like the vast majority of other .NET code.
+    /// However, the legacy ShellExecutor API would swallow OperationCanceledException exceptions on cancellation, so this
+    /// option exists to preserve that behaviour where necessary.
+    /// </summary>
+    DoNotThrowOnCancellation,
+}

--- a/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
+++ b/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
@@ -12,8 +12,12 @@ Octopus.Shellfish.ShellCommand.WithCredentials
 Octopus.Shellfish.ShellCommand.WithOutputEncoding
 Octopus.Shellfish.ShellCommand.WithStdOutTarget
 Octopus.Shellfish.ShellCommand.WithStdErrTarget
+Octopus.Shellfish.ShellCommand.WithOptions
 Octopus.Shellfish.ShellCommand.Execute
 Octopus.Shellfish.ShellCommand.ExecuteAsync
+Octopus.Shellfish.ShellCommandOptions.value__
+Octopus.Shellfish.ShellCommandOptions.None
+Octopus.Shellfish.ShellCommandOptions.DoNotThrowOnCancellation
 Octopus.Shellfish.ShellCommandResult.ExitCode
 Octopus.Shellfish.ShellExecutionException.Errors
 Octopus.Shellfish.ShellExecutionException.Message


### PR DESCRIPTION
# Background

When the new `ShellCommand` API was added, we chose to preserve the cancellation behaviour of the old `ShellExecutor` API.

The legacy behaviour is such:
- You call `Execute(cancellationToken)`;
- The token gets cancelled before the process exits;
- Shellfish would terminate the launched process ;
- **However** it would NOT throw an `OperationCanceledException`, it would return successfully. This contradicts the behaviour of essentially all other cancellable functions in .NET.

This "preservation" behaviour was chosen to make migrating other code to the new API easier, and seemed sensible at the time.

However, we have since learnt:
- The cost of the weird legacy API was higher than expected; it has confused people on multiple occasions when they've reviewed or tried to use the new Shellfish
- The **primary** reason we wanted to preserve the old behaviour was because we thought Task execution in Octopus Server used this exception-swallowing behaviour, and it's an area we have to be extremely careful with if/when we migrate it to the new Shellfish API. However it was re-discovered that [since November 2023, Octopus Server doesn't expect exception-swallowing anyway](https://github.com/OctopusDeploy/OctopusDeploy/pull/21506)

# Results

- Adds a new `enum ShellCommandOptions` with values `None` and `DoNotThrowOnCancellation`

- Adds a new `WithOptions` function to `ShellCommand`, so you can do `command.WithOptions(ShellCommandOptions.DoNotThrowOnCancellation);`

- Changes the default behaviour so it rethrows the underlying `OperationCanceledException` as per other .NET code.

- Updates tests accordingly

**Note** There were two extra test changes here

- A `CaptureProcess` method was added to ShellCommand. This is to allow tests to get the `System.Diagnostics.Process` object and assert that a process has actually exited. Deliberately non-public as we don't want to commit to that level of information in the public API yet.

- Tests that wanted to block used to run `cmd` or `bash` with no arguments, expecting them to wait forever for stdinput. We recently learnt that in linux on TeamCity, bash is capable of determining that it has no stdinput and is not running interactively and exits immediately, which would invalidate the test. I switched to using "sleep" on linux and "timeout.exe" on windows instead of relying on stdinput.

