### PR TITLE
Fix flaky Windows test

### DIFF
--- a/source/Tests/ShellCommandFixture.cs
+++ b/source/Tests/ShellCommandFixture.cs
@@ -138,7 +138,7 @@ public class ShellCommandFixture
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             // timeout.exe will return 1 when interrupted
-            exitCode.Should().BeOneOf([-1, 0, 1], "the process should have been terminated");
+            exitCode.Should().BeOneOf([-1, 1], "the process should have been terminated");
         }
         else
         {

--- a/source/Tests/ShellCommandFixture.cs
+++ b/source/Tests/ShellCommandFixture.cs
@@ -137,7 +137,8 @@ public class ShellCommandFixture
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            exitCode.Should().BeLessOrEqualTo(0, "the process should have been terminated");
+            // timeout.exe will return 1 when interrupted
+            exitCode.Should().BeOneOf([-1, 0, 1], "the process should have been terminated");
         }
         else
         {


### PR DESCRIPTION
The test in question runs the `timeout.exe` program on Windows, then cancels it, verifying that an exception is not throw. It requires that the exit code of the program is 0 or lower. However, `timeout.exe` will return 1 when it is interrupted:

```
>timeout /t 500 /nobreak

Waiting for 496 seconds, press CTRL+C to quit ...

>echo %ERRORLEVEL%
1

>
```

This fails quite reliably on both the sync and async cases. It is unclear as to why it doesn't always fail. It's possible that there are timing implications involved which make the exit code inconsistent.