### PR TITLE
Fix usages of SafeHandle

### DIFF
--- a/source/Shellfish/Windows/AccessToken.cs
+++ b/source/Shellfish/Windows/AccessToken.cs
@@ -39,16 +39,16 @@ namespace Octopus.Shellfish.Windows
             LogonProvider logonProvider = LogonProvider.Default)
         {
             // See https://msdn.microsoft.com/en-us/library/windows/desktop/aa378184(v=vs.85).aspx
-            var hToken = IntPtr.Zero;
+            SafeAccessTokenHandle? handle = null;
             Win32Helper.Invoke(() => LogonUser(username,
                     domain,
                     password,
                     LogonType.Network,
                     LogonProvider.Default,
-                    out hToken),
+                    out handle),
                 $"Logon failed for the user '{username}'");
 
-            return new AccessToken(username, new SafeAccessTokenHandle(hToken));
+            return new AccessToken(username, handle!);
         }
 
         public void Dispose()
@@ -63,7 +63,7 @@ namespace Octopus.Shellfish.Windows
             string password,
             LogonType logonType,
             LogonProvider logonProvider,
-            out IntPtr hToken);
+            out SafeAccessTokenHandle hToken);
 #pragma warning restore PC003 // Native API not available in UWP
     }
 }

--- a/source/Shellfish/Windows/NonReleasingSafeHandle.cs
+++ b/source/Shellfish/Windows/NonReleasingSafeHandle.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Octopus.Shellfish.Windows;
+
+class NonReleasingSafeHandle() : SafeHandle(IntPtr.Zero, false)
+{
+    public override bool IsInvalid => false;
+
+    protected override bool ReleaseHandle() => true;
+}

--- a/source/Shellfish/Windows/SafeAccessTokenHandle.cs
+++ b/source/Shellfish/Windows/SafeAccessTokenHandle.cs
@@ -1,19 +1,11 @@
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace Octopus.Shellfish.Windows
 {
-    sealed class SafeAccessTokenHandle : SafeHandle
+    sealed class SafeAccessTokenHandle() : SafeHandleZeroOrMinusOneIsInvalid(true)
     {
-        // 0 is an Invalid Handle
-        public SafeAccessTokenHandle(IntPtr handle) : base(handle, true)
-        {
-        }
-
-        public static SafeAccessTokenHandle InvalidHandle => new SafeAccessTokenHandle(IntPtr.Zero);
-
-        public override bool IsInvalid => handle == IntPtr.Zero || handle == new IntPtr(-1);
-
         protected override bool ReleaseHandle()
             => CloseHandle(handle);
 

--- a/source/Shellfish/Windows/Win32Helper.cs
+++ b/source/Shellfish/Windows/Win32Helper.cs
@@ -1,46 +1,24 @@
 using System;
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace Octopus.Shellfish.Windows
 {
     static class Win32Helper
     {
-        public static bool Invoke(Func<bool> nativeMethod, string failureDescription)
+        public static void Invoke(Func<bool> nativeMethod, string failureDescription)
         {
-            try
+            if (!nativeMethod())
             {
-                return nativeMethod() ? true : throw new Win32Exception();
-            }
-            catch (Win32Exception ex)
-            {
-                throw new Exception($"{failureDescription}: {ex.Message}", ex);
+                throw new Exception(failureDescription, new Win32Exception());
             }
         }
 
-        public static T Invoke<T>(Func<T> nativeMethod, Func<T, bool> successful, string failureDescription)
+        public static THandle Invoke<THandle>(Func<THandle> nativeMethod, string failureDescription)
+            where THandle : SafeHandle
         {
-            try
-            {
-                var result = nativeMethod();
-                return successful(result) ? result : throw new Win32Exception();
-            }
-            catch (Win32Exception ex)
-            {
-                throw new Exception($"{failureDescription}: {ex.Message}", ex);
-            }
-        }
-
-        public static IntPtr Invoke(Func<IntPtr> nativeMethod, string failureDescription)
-        {
-            try
-            {
-                var result = nativeMethod();
-                return result != IntPtr.Zero ? result : throw new Win32Exception();
-            }
-            catch (Win32Exception ex)
-            {
-                throw new Exception($"{failureDescription}: {ex.Message}", ex);
-            }
+            var result = nativeMethod();
+            return !result.IsInvalid ? result : throw new Exception(failureDescription, new Win32Exception());
         }
     }
 }

--- a/source/Shellfish/Windows/WindowStationAndDesktopAccess.cs
+++ b/source/Shellfish/Windows/WindowStationAndDesktopAccess.cs
@@ -118,19 +118,6 @@ namespace Octopus.Shellfish.Windows
                 => throw new NotImplementedException();
         }
 
-        class NoopSafeHandle : SafeHandle
-        {
-            public NoopSafeHandle(IntPtr handle) :
-                base(handle, false)
-            {
-            }
-
-            public override bool IsInvalid => false;
-
-            protected override bool ReleaseHandle()
-                => true;
-        }
-
 #pragma warning disable PC003 // Native API not available in UWP
         // Handles returned by GetProcessWindowStation and GetThreadDesktop should not be closed
         [DllImport("user32.dll", SetLastError = true)]


### PR DESCRIPTION
# Background

Some of our usages of `SafeHandle` are not safe. This type is designed to work with the P/Invoke system to ensure that handles returned from native calls can't leak.

In a couple of spots we make a native call and retrieve a Windows handle represented by an `IntPtr`, then subsequently wrap this in a `SafeHandle`. There is an opportunity, though perhaps only theoretical, that something goes wrong in between, the handle is never wrapped, and thus may leak.

# Result

Use the `SafeHandle` types as the return types for the P/Invoke calls, ensuring the handles are wrapped atomically.