### PR TITLE
Remove the need for unsafe code blocks

### DIFF
--- a/source/Shellfish/Shellfish.csproj
+++ b/source/Shellfish/Shellfish.csproj
@@ -10,7 +10,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>12</LangVersion>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Currently we use unsafe code (i.e. pointers) to parse environment blocks returned from the `CreateEnvironmentBlock` API. This can instead be done using methods on the `Marshal` class, removing the need for unsafe code blocks in the project.

Benchmarking the two different approaches, the speed is roughly equivalent. Around 22% less memory is allocated using the `Marshal` approach.

```
| Method        | Mean     | Error   | StdDev  | Gen0   | Allocated |
|-------------- |---------:|--------:|--------:|-------:|----------:|
| WithUnsafe    | 352.4 us | 4.21 us | 3.73 us | 2.4414 |  31.81 KB |
| WithoutUnsafe | 352.8 us | 6.31 us | 5.90 us | 1.9531 |  24.59 KB |
```