### PR TITLE
Don't use `SafeHandle` for handle we shouldn't close

### DIFF
--- a/source/Shellfish/Windows/Interop.cs
+++ b/source/Shellfish/Windows/Interop.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
 
 namespace Octopus.Shellfish.Windows;
 
@@ -114,7 +113,7 @@ static class Interop
         // See https://msdn.microsoft.com/en-us/library/windows/desktop/bb762282(v=vs.85).aspx
         // This function closes the registry handle for the user profile too
         [DllImport(Libraries.Userenv, SetLastError = true)]
-        internal static extern bool UnloadUserProfile(SafeAccessTokenHandle hToken, SafeRegistryHandle hProfile);
+        internal static extern bool UnloadUserProfile(SafeAccessTokenHandle hToken, IntPtr hProfile);
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct ProfileInfo


### PR DESCRIPTION
The `UserProfile` class invokes the `LoadUserProfile` API, the result of which includes an open handle to the user's registry hive. Per [the documentation](https://learn.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-loaduserprofilea#remarks), this handle should not be closed, but instead passed to `UnloadUserProfile`. Currently, we wrap the returned handle in a `SafeHandle`.

The handle is not owned by the `SafeHandle`, so it won't be closed on disposal/finalization, but the usage is a bit confusing and unnecessary. Simply flipping the `false` to a `true` in the constructor would potentially double-release the handle, which is an issue we've seen previously.

Just passing around the raw handle makes it clearer how it is being used.