### PR TITLE
Implement ToString on ShellCommand

### DIFF
--- a/source/Shellfish/ShellCommand.cs
+++ b/source/Shellfish/ShellCommand.cs
@@ -209,7 +209,19 @@ public class ShellCommand
 
     public override string ToString()
     {
-        var arguments = argumentList != null ? string.Join(" ", argumentList) : argumentString;
+        var arguments = string.Empty;
+        if (argumentString is not null && argumentList is { Count: > 0 })
+            throw new InvalidOperationException();
+
+        if (argumentString is not null)
+        {
+            arguments = argumentString;
+        }
+        else if (argumentList is { Count: > 0 })
+        {
+            arguments = PasteArguments.JoinArguments(argumentList);
+        }
+
         return $"{executable} {arguments}";
     }
 }

--- a/source/Shellfish/ShellCommand.cs
+++ b/source/Shellfish/ShellCommand.cs
@@ -124,7 +124,7 @@ public class ShellCommand
 
     /// <summary>
     /// Adds an output target for the standard output stream of the process.
-    /// Typically, an extension method like WithStdOutTarget(StringBuilder) or WithStdOutTarget(Action&lt;string&gt;) would be used over this. 
+    /// Typically, an extension method like WithStdOutTarget(StringBuilder) or WithStdOutTarget(Action&lt;string&gt;) would be used over this.
     /// </summary>
     public ShellCommand WithStdOutTarget(IOutputTarget target)
     {
@@ -142,7 +142,7 @@ public class ShellCommand
 
     /// <summary>
     /// Adds an output target for the standard error stream of the process.
-    /// Typically, an extension method like WithStdErrTarget(StringBuilder) or WithStdErrTarget(Action&lt;string&gt;) would be used over this. 
+    /// Typically, an extension method like WithStdErrTarget(StringBuilder) or WithStdErrTarget(Action&lt;string&gt;) would be used over this.
     /// </summary>
     public ShellCommand WithStdErrTarget(IOutputTarget target)
     {
@@ -205,5 +205,11 @@ public class ShellCommand
         await process.WaitForExitAsync(cancellationToken);
 
         return new ShellCommandResult(process.SafelyGetExitCode());
+    }
+
+    public override string ToString()
+    {
+        var arguments = argumentList != null ? string.Join(" ", argumentList) : argumentString;
+        return $"{executable} {arguments}";
     }
 }

--- a/source/Shellfish/ShellCommand.cs
+++ b/source/Shellfish/ShellCommand.cs
@@ -211,9 +211,10 @@ public class ShellCommand
     {
         var arguments = string.Empty;
         if (argumentString is not null && argumentList is { Count: > 0 })
-            throw new InvalidOperationException();
-
-        if (argumentString is not null)
+        {
+            arguments = "<invalid arguments: both argumentString and argumentList have been supplied>";
+        }
+        else if (argumentString is not null)
         {
             arguments = argumentString;
         }

--- a/source/Shellfish/ShellCommand.cs
+++ b/source/Shellfish/ShellCommand.cs
@@ -209,18 +209,28 @@ public class ShellCommand
 
     public override string ToString()
     {
-        var arguments = string.Empty;
+        return ToString(false);
+    }
+
+    public string ToString(bool includeArguments)
+    {
+        var arguments = "<arguments>";
+
         if (argumentString is not null && argumentList is { Count: > 0 })
         {
             arguments = "<invalid arguments: both argumentString and argumentList have been supplied>";
         }
         else if (argumentString is not null)
         {
-            arguments = argumentString;
+            arguments = includeArguments
+                ? argumentString
+                : "<arguments>";
         }
         else if (argumentList is { Count: > 0 })
         {
-            arguments = PasteArguments.JoinArguments(argumentList);
+            arguments = includeArguments
+                ? PasteArguments.JoinArguments(argumentList)
+                : $"<{argumentList.Count} arguments>";
         }
 
         return $"{executable} {arguments}";

--- a/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
+++ b/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
@@ -15,6 +15,7 @@ Octopus.Shellfish.ShellCommand.WithStdErrTarget
 Octopus.Shellfish.ShellCommand.WithOptions
 Octopus.Shellfish.ShellCommand.Execute
 Octopus.Shellfish.ShellCommand.ExecuteAsync
+Octopus.Shellfish.ShellCommand.ToString
 Octopus.Shellfish.ShellCommandOptions.value__
 Octopus.Shellfish.ShellCommandOptions.None
 Octopus.Shellfish.ShellCommandOptions.DoNotThrowOnCancellation

--- a/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
+++ b/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
@@ -16,6 +16,7 @@ Octopus.Shellfish.ShellCommand.WithOptions
 Octopus.Shellfish.ShellCommand.Execute
 Octopus.Shellfish.ShellCommand.ExecuteAsync
 Octopus.Shellfish.ShellCommand.ToString
+Octopus.Shellfish.ShellCommand.ToString
 Octopus.Shellfish.ShellCommandOptions.value__
 Octopus.Shellfish.ShellCommandOptions.None
 Octopus.Shellfish.ShellCommandOptions.DoNotThrowOnCancellation

--- a/source/Tests/ShellCommandFixture.cs
+++ b/source/Tests/ShellCommandFixture.cs
@@ -394,6 +394,16 @@ public class ShellCommandFixture
         command.ToString().Should().Be("echo apple \"banana split\" \"--thing=\\\"quotedValue\\\"\" --option cherry");
     }
 
+    [Fact]
+    public void ToStringDoesNotThrowWithInvalidArguments()
+    {
+        var command = new ShellCommand("echo")
+            .WithArguments(["hello"])
+            .WithArguments("world");
+
+        command.ToString().Should().Be("echo <invalid arguments: both argumentString and argumentList have been supplied>");
+    }
+
     static string EchoEnvironmentVariable(string varName)
         => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"%{varName}%" : $"${varName}";
 }

--- a/source/Tests/ShellCommandFixture.cs
+++ b/source/Tests/ShellCommandFixture.cs
@@ -368,16 +368,16 @@ public class ShellCommandFixture
     }
 
     [Fact]
-    public void ToStringWorksForArgumentString()
+    public void ToStringWithArgumentsWorksForArgumentString()
     {
         var command = new ShellCommand("echo")
             .WithArguments("hello world");
 
-        command.ToString().Should().Be("echo hello world");
+        command.ToString(true).Should().Be("echo hello world");
     }
 
     [Fact]
-    public void ToStringWorksForArgumentList()
+    public void ToStringWithArgumentsWorksForArgumentList()
     {
         string[] inputArgs =
         [
@@ -391,7 +391,34 @@ public class ShellCommandFixture
         var command = new ShellCommand("echo")
             .WithArguments(inputArgs);
 
-        command.ToString().Should().Be("echo apple \"banana split\" \"--thing=\\\"quotedValue\\\"\" --option cherry");
+        command.ToString(true).Should().Be("echo apple \"banana split\" \"--thing=\\\"quotedValue\\\"\" --option cherry");
+    }
+
+    [Fact]
+    public void ToStringWithoutArgumentsOmitsArgumentsString()
+    {
+        var command = new ShellCommand("echo")
+            .WithArguments("hello world");
+
+        command.ToString().Should().Be("echo <arguments>");
+    }
+
+    [Fact]
+    public void ToStringWithoutArgumentsOmitsArgumentsList()
+    {
+        string[] inputArgs =
+        [
+            "apple",
+            "banana split",
+            "--thing=\"quotedValue\"",
+            "--option",
+            "cherry"
+        ];
+
+        var command = new ShellCommand("echo")
+            .WithArguments(inputArgs);
+
+        command.ToString().Should().Be("echo <5 arguments>");
     }
 
     [Fact]

--- a/source/Tests/ShellCommandFixture.cs
+++ b/source/Tests/ShellCommandFixture.cs
@@ -105,7 +105,7 @@ public class ShellCommandFixture
         {
             executor.Invoking(e => e.Execute(cancellationToken)).Should().Throw<OperationCanceledException>();
         }
-        
+
         // we can't observe any exit code because Execute() threw an exception
 
         process?.Should().NotBeNull();
@@ -118,7 +118,7 @@ public class ShellCommandFixture
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
         // Terminate the process after a short time so the test doesn't run forever
         cts.CancelAfter(TimeSpan.FromSeconds(0.5));
-        
+
         var executor = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? new ShellCommand("timeout.exe").WithArguments("/t 500 /nobreak")
             : new ShellCommand("bash").WithArguments("-c \"sleep 500\"");
@@ -352,7 +352,7 @@ public class ShellCommandFixture
         stdErr.ToString().Should().BeEmpty("no messages should be written to stderr");
 
         var expectedQuotedValue = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? "--thing=\\\"quotedValue\\\"" // on windows echo adds extra quoting; this is an artifact of cmd.exe not our code 
+            ? "--thing=\\\"quotedValue\\\"" // on windows echo adds extra quoting; this is an artifact of cmd.exe not our code
             : "--thing=\"quotedValue\"";
 
         stdOut.ToString()
@@ -365,6 +365,33 @@ public class ShellCommandFixture
                 "cherry",
                 "" // it has a trailing newline at the end
             ]));
+    }
+
+    [Fact]
+    public void ToStringWorksForArgumentString()
+    {
+        var command = new ShellCommand("echo")
+            .WithArguments("hello world");
+
+        command.ToString().Should().Be("echo hello world");
+    }
+
+    [Fact]
+    public void ToStringWorksForArgumentList()
+    {
+        string[] inputArgs =
+        [
+            "apple",
+            "banana split",
+            "--thing=\"quotedValue\"",
+            "--option",
+            "cherry"
+        ];
+
+        var command = new ShellCommand("echo")
+            .WithArguments(inputArgs);
+
+        command.ToString().Should().Be("echo apple \"banana split\" \"--thing=\\\"quotedValue\\\"\" --option cherry");
     }
 
     static string EchoEnvironmentVariable(string varName)


### PR DESCRIPTION
I have a use case where I'd like to be able to print the `ShellCommand` before executing it. Example:
```cs
var command = new ShellCommand("echo")
    .WithArguments(["hello", "world"]);

Console.WriteLine($"Executing {command}")
command.Execute();
```

The other way to achieve this right now would be to create a wrapper method, which isn't ideal for my use case:
```cs
public void ExecuteWithLogging(string command, string[] args)
{
    var command = new ShellCommand(command)
        .WithArguments(args);

    var args = string.Join(" ", args);
    Console.WriteLine($"Executing {command} {args}");

    command.Execute();
}
```

This PR implements the `.ToString()` method on `ShellCommand` for use in string formatting.