### PR TITLE
Make ShellCommand.CaptureProcess public

### DIFF
--- a/source/Shellfish/ShellCommand.cs
+++ b/source/Shellfish/ShellCommand.cs
@@ -34,8 +34,10 @@ public class ShellCommand
         this.executable = executable;
     }
 
-    // internal only, so tests can assert if a process has exited or not.
-    internal ShellCommand CaptureProcess(Action<Process> onProcess)
+    /// <summary>
+    /// Allows you to access the underlying <see cref="Process"/> as soon as it is spawned for advanced use cases.
+    /// </summary>
+    public ShellCommand CaptureProcess(Action<Process> onProcess)
     {
         onCaptureProcess = onProcess;
         return this;

--- a/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
+++ b/source/Tests/PublicSurfaceArea.TheLibraryOnlyExposesWhatWeWantItToExpose.approved.txt
@@ -4,6 +4,7 @@ Octopus.Shellfish.ShellCommandExtensionMethods.WithStdErrTarget
 Octopus.Shellfish.ShellCommandExtensionMethods.WithStdOutTarget
 Octopus.Shellfish.ShellCommandExtensionMethods.WithStdErrTarget
 Octopus.Shellfish.IOutputTarget.WriteLine
+Octopus.Shellfish.ShellCommand.CaptureProcess
 Octopus.Shellfish.ShellCommand.WithWorkingDirectory
 Octopus.Shellfish.ShellCommand.WithArguments
 Octopus.Shellfish.ShellCommand.WithArguments


### PR DESCRIPTION
To the best of my knowledge there is currently no way to access detailed process information such as the process ID of the spawned process via the `ShellCommand` abstraction. There is however an internal `CaptureProcess` method originally implemented for test purposes.

This PR proposes making this public so that consumers can gain access to the underlying `Process` and all its information as soon as it's spawned, via the fluent API.